### PR TITLE
 Disable KGLS throttle.

### DIFF
--- a/drivers/gpu/msm/adreno_sysfs.c
+++ b/drivers/gpu/msm/adreno_sysfs.c
@@ -21,6 +21,13 @@ struct adreno_sysfs_attribute adreno_attr_##_name = { \
 	.store = _ ## _name ## _store, \
 }
 
+#define _ADRENO_SYSFS_FPERM_ATTR(_name, _fperm, __show, __store) \
+struct adreno_sysfs_attribute adreno_attr_##_name = { \
+	.attr = __ATTR(_name, _fperm, __show, __store), \
+	.show = _ ## _name ## _show, \
+	.store = _ ## _name ## _store, \
+}
+
 #define _ADRENO_SYSFS_ATTR_RO(_name, __show) \
 struct adreno_sysfs_attribute adreno_attr_##_name = { \
 	.attr = __ATTR(_name, 0444, __show, NULL), \
@@ -258,7 +265,7 @@ static unsigned int _hwcg_show(struct adreno_device *adreno_dev)
 static int _throttling_store(struct adreno_device *adreno_dev,
 	unsigned int val)
 {
-	return _pwrctrl_store(adreno_dev, val, ADRENO_THROTTLING_CTRL);
+	return 0;
 }
 
 static unsigned int _throttling_show(struct adreno_device *adreno_dev)
@@ -413,6 +420,9 @@ static ssize_t _sysfs_show_bool(struct device *dev,
 
 #define ADRENO_SYSFS_BOOL(_name) \
 	_ADRENO_SYSFS_ATTR(_name, _sysfs_show_bool, _sysfs_store_bool)
+	
+#define ADRENO_SYSFS_RO_BOOL(_name) \
+	_ADRENO_SYSFS_FPERM_ATTR(_name, 0444, _sysfs_show_bool, _sysfs_store_bool)
 
 #define ADRENO_SYSFS_U32(_name) \
 	_ADRENO_SYSFS_ATTR(_name, _sysfs_show_u32, _sysfs_store_u32)
@@ -437,7 +447,7 @@ static ADRENO_SYSFS_BOOL(sptp_pc);
 static ADRENO_SYSFS_BOOL(lm);
 static ADRENO_SYSFS_BOOL(preemption);
 static ADRENO_SYSFS_BOOL(hwcg);
-static ADRENO_SYSFS_BOOL(throttling);
+static ADRENO_SYSFS_RO_BOOL(throttling);
 static ADRENO_SYSFS_BOOL(ifpc);
 static ADRENO_SYSFS_RO_U32(ifpc_count);
 static ADRENO_SYSFS_BOOL(acd);


### PR DESCRIPTION
Stop locking GPU at very low MHz when battery is at 44º.